### PR TITLE
Fix nsvals for svehintsreduced

### DIFF
--- a/include/sparseir/kernel.hpp
+++ b/include/sparseir/kernel.hpp
@@ -1136,7 +1136,7 @@ public:
     {
         // Implement this function
         // For example, you can delegate the call to the inner object
-        return inner->nsvals();
+        return (inner->nsvals() + 1) / 2;
     }
 
     int ngauss() const override


### PR DESCRIPTION
This PR fixes C++ implementation corresponds to the following Julia code:

```julia
function nsvals(hints::SVEHintsReduced)
    return (nsvals(hints.inner_hints) + 1) ÷ 2
end
```