### PR TITLE
Fix choose_accuracy implementation

### DIFF
--- a/include/sparseir/sve.hpp
+++ b/include/sparseir/sve.hpp
@@ -80,7 +80,7 @@ choose_accuracy(double epsilon, const std::string &Twork)
         }
     } else {
         // Handle the case for xprec::DDouble
-        if (epsilon >= std::sqrt(std::numeric_limits<double>::epsilon())) {
+        if (epsilon >= sqrt_impl(std::numeric_limits<xprec::DDouble>::epsilon())) {
             return std::make_tuple(epsilon, Twork, "default");
         } else {
             std::cerr << "Warning: Basis cutoff is " << epsilon


### PR DESCRIPTION
 Use `xprec::DDouble` rather than `double` if `Twork` is `Float64x2`