### PR TITLE
Change C-API name for `fit` and `evaluate`

### DIFF
--- a/include/sparseir/sampling.hpp
+++ b/include/sparseir/sampling.hpp
@@ -325,7 +325,7 @@ public:
         }
 
     // Evaluate the basis functions at the sampling points with complex input and complex output
-    virtual int evaluate_inplace_cc(
+    virtual int evaluate_inplace_zz(
         const Eigen::TensorMap<const Eigen::Tensor<std::complex<double>, 3>> &/*input*/,
         int /*dim*/,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &/*output*/) const {
@@ -333,7 +333,7 @@ public:
         }
 
     // Evaluate the basis functions at the sampling points with double input and complex output
-    virtual int evaluate_inplace_dc(
+    virtual int evaluate_inplace_dz(
         const Eigen::TensorMap<const Eigen::Tensor<double, 3>> &/*input*/,
         int /*dim*/,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &/*output*/) const {
@@ -349,7 +349,7 @@ public:
         }
 
     // Fit basis coefficients from the sparse sampling points with complex input and complex output
-    virtual int fit_inplace_cc(
+    virtual int fit_inplace_zz(
         const Eigen::TensorMap<const Eigen::Tensor<std::complex<double>, 3>> &/*input*/,
         int /*dim*/,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &/*output*/) const {
@@ -357,7 +357,7 @@ public:
         }
 
     // Fit basis coefficients from the sparse sampling points with complex input and double output
-    virtual int fit_inplace_cd(
+    virtual int fit_inplace_dz(
         const Eigen::TensorMap<const Eigen::Tensor<std::complex<double>, 3>> &/*input*/,
         int /*dim*/,
         Eigen::TensorMap<Eigen::Tensor<double, 3>> &/*output*/) const {
@@ -511,17 +511,17 @@ public:
     // Implement evaluate_inplace_dd method using the common implementation
     // Error code: -1: invalid dimension, -2: dimension mismatch, -3: type not
     // supported
-    int evaluate_inplace_cc(
+    int evaluate_inplace_zz(
         const Eigen::TensorMap<const Eigen::Tensor<std::complex<double>, 3>> &input,
         int dim,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &output) const override{
         return evaluate_inplace_impl<TauSampling<S>, std::complex<double>, std::complex<double>, 3>(
             *this, input, dim, output);
     }
-    // Implement fit_inplace_cc method using the common implementation
+    // Implement fit_inplace_zz method using the common implementation
     // Error code: -1: invalid dimension, -2: dimension mismatch, -3: type not
     // supported
-    int fit_inplace_cc(
+    int fit_inplace_zz(
         const Eigen::TensorMap<const Eigen::Tensor<std::complex<double>, 3>> &input,
         int dim,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &output) const override{
@@ -679,27 +679,27 @@ public:
         return static_cast<std::size_t>(matrix_.cols());
     }
 
-    // Implement evaluate_inplace_dc method using the common implementation
+    // Implement evaluate_inplace_dz method using the common implementation
     // Error code: -1: invalid dimension, -2: dimension mismatch, -3: type not supported
-    int evaluate_inplace_dc(
+    int evaluate_inplace_dz(
         const Eigen::TensorMap<const Eigen::Tensor<double, 3>> &input,
         int dim,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &output) const override {
         return evaluate_inplace_impl<MatsubaraSampling<S>, double, std::complex<double>, 3>(*this, input, dim, output);
     }
 
-    // Implement evaluate_inplace_cc method using the common implementation
+    // Implement evaluate_inplace_zz method using the common implementation
     // Error code: -1: invalid dimension, -2: dimension mismatch, -3: type not supported
-    int evaluate_inplace_cc (
+    int evaluate_inplace_zz (
         const Eigen::TensorMap<const Eigen::Tensor<std::complex<double>, 3>> &input,
         int dim,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &output) const override {
         return evaluate_inplace_impl<MatsubaraSampling<S>, std::complex<double>, std::complex<double>, 3>(*this, input, dim, output);
     }
 
-    // Implement fit_inplace_cc method using the common implementation
+    // Implement fit_inplace_zz method using the common implementation
     // Error code: -1: invalid dimension, -2: dimension mismatch, -3: type not supported
-    int fit_inplace_cc (
+    int fit_inplace_zz (
         const Eigen::TensorMap<const Eigen::Tensor<std::complex<double>, 3>> &input,
         int dim,
         Eigen::TensorMap<Eigen::Tensor<std::complex<double>, 3>> &output) const override {

--- a/include/sparseir/sparseir.h
+++ b/include/sparseir/sparseir.h
@@ -132,7 +132,7 @@ int spir_sampling_evaluate_dd(
     double *out                    // Output array
     );
 
-int spir_sampling_evaluate_dc(
+int spir_sampling_evaluate_dz(
     const spir_sampling *s,        // Sampling object
     spir_order_type order,         // Order type (C or Fortran)
     int32_t ndim,                  // Number of dimensions
@@ -142,7 +142,7 @@ int spir_sampling_evaluate_dc(
     std::complex<double> *out                    // Output array
     );
 
-int spir_sampling_evaluate_cc(
+int spir_sampling_evaluate_zz(
     const spir_sampling *s,        // Sampling object
     spir_order_type order,         // Order type (C or Fortran)
     int32_t ndim,                  // Number of dimensions
@@ -163,7 +163,7 @@ int spir_sampling_fit_dd(
     double *out                    // Output array
     );
 
-int spir_sampling_fit_cc(
+int spir_sampling_fit_zz(
     const spir_sampling *s,        // Sampling object
     spir_order_type order,         // Order type (C or Fortran)
     int32_t ndim,                  // Number of dimensions

--- a/src/cinterface.cpp
+++ b/src/cinterface.cpp
@@ -468,7 +468,7 @@ int spir_sampling_evaluate_dd(
                         &sparseir::AbstractSampling::evaluate_inplace_dd);
 }
 
-int spir_sampling_evaluate_dc(
+int spir_sampling_evaluate_dz(
     const spir_sampling *s,
     spir_order_type order,
     int32_t ndim,
@@ -478,10 +478,10 @@ int spir_sampling_evaluate_dc(
     std::complex<double> *out)
 {
     return evaluate_impl(s, order, ndim, input_dims, target_dim, input, out,
-                        &sparseir::AbstractSampling::evaluate_inplace_dc);
+                        &sparseir::AbstractSampling::evaluate_inplace_dz);
 }
 
-int spir_sampling_evaluate_cc(
+int spir_sampling_evaluate_zz(
     const spir_sampling *s,
     spir_order_type order,
     int32_t ndim,
@@ -491,7 +491,7 @@ int spir_sampling_evaluate_cc(
     std::complex<double> *out)
 {
     return evaluate_impl(s, order, ndim, input_dims, target_dim, input, out,
-                        &sparseir::AbstractSampling::evaluate_inplace_cc);
+                        &sparseir::AbstractSampling::evaluate_inplace_zz);
 }
 
 int spir_sampling_fit_dd(
@@ -507,7 +507,7 @@ int spir_sampling_fit_dd(
                         &sparseir::AbstractSampling::fit_inplace_dd);
 }
 
-int spir_sampling_fit_cc(
+int spir_sampling_fit_zz(
     const spir_sampling *s,
     spir_order_type order,
     int32_t ndim,
@@ -517,7 +517,7 @@ int spir_sampling_fit_cc(
     std::complex<double> *out)
 {
     return fit_impl(s, order, ndim, input_dims, target_dim, input, out,
-                        &sparseir::AbstractSampling::fit_inplace_cc);
+                        &sparseir::AbstractSampling::fit_inplace_zz);
 }
 
 

--- a/test/cinterface.cxx
+++ b/test/cinterface.cxx
@@ -540,7 +540,7 @@ TEST_CASE("TauSampling", "[cinterface]") {
                 }
             }
             // Evaluate using C API
-            int evaluate_status = spir_sampling_evaluate_cc(
+            int evaluate_status = spir_sampling_evaluate_zz(
                 sampling,
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
@@ -552,7 +552,7 @@ TEST_CASE("TauSampling", "[cinterface]") {
 
             REQUIRE(evaluate_status == 0);
 
-            int fit_status = spir_sampling_fit_cc(
+            int fit_status = spir_sampling_fit_zz(
                 sampling,
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
@@ -749,7 +749,7 @@ TEST_CASE("TauSampling", "[cinterface]") {
             int target_dim = dim;
 
             // Evaluate using C API
-            int evaluate_status = spir_sampling_evaluate_cc(
+            int evaluate_status = spir_sampling_evaluate_zz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -760,7 +760,7 @@ TEST_CASE("TauSampling", "[cinterface]") {
             );
             REQUIRE(evaluate_status == 0);
 
-            int fit_status = spir_sampling_fit_cc(
+            int fit_status = spir_sampling_fit_zz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -840,7 +840,7 @@ TEST_CASE("TauSampling", "[cinterface]") {
             int target_dim = dim;
 
             // Evaluate using C API that is not supported
-            int status_not_supported = spir_sampling_evaluate_dc(
+            int status_not_supported = spir_sampling_evaluate_dz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -958,7 +958,7 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
             int target_dim = dim;
 
             // Evaluate using C API
-            int evaluate_status = spir_sampling_evaluate_dc(
+            int evaluate_status = spir_sampling_evaluate_dz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -969,7 +969,7 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
             );
             REQUIRE(evaluate_status == 0);
 
-            int fit_status = spir_sampling_fit_cc(
+            int fit_status = spir_sampling_fit_zz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -1052,7 +1052,7 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
             int target_dim = dim;
 
             // Evaluate using C API
-            int evaluate_status = spir_sampling_evaluate_cc(
+            int evaluate_status = spir_sampling_evaluate_zz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -1063,7 +1063,7 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
             );
             REQUIRE(evaluate_status == 0);
 
-            int fit_status = spir_sampling_fit_cc(
+            int fit_status = spir_sampling_fit_zz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -1163,12 +1163,12 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
                 }
             }
             // Evaluate using C API
-            int evaluate_status = spir_sampling_evaluate_dc(
+            int evaluate_status = spir_sampling_evaluate_dz(
                 sampling, SPIR_ORDER_ROW_MAJOR, ndim, dims, target_dim,
                 gl_cpp_rowmajor.data(), evaluate_output);
             REQUIRE(evaluate_status == 0);
 
-            int fit_status = spir_sampling_fit_cc(
+            int fit_status = spir_sampling_fit_zz(
                 sampling, SPIR_ORDER_ROW_MAJOR, ndim, dims, target_dim,
                 evaluate_output, fit_output);
             REQUIRE(fit_status == 0);
@@ -1279,12 +1279,12 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
                 }
             }
             // Evaluate using C API
-            int evaluate_status = spir_sampling_evaluate_cc(
+            int evaluate_status = spir_sampling_evaluate_zz(
                 sampling, SPIR_ORDER_ROW_MAJOR, ndim, dims, target_dim,
                 gl_cpp_rowmajor.data(), evaluate_output);
             REQUIRE(evaluate_status == 0);
 
-            int fit_status = spir_sampling_fit_cc(
+            int fit_status = spir_sampling_fit_zz(
                 sampling, SPIR_ORDER_ROW_MAJOR, ndim, dims, target_dim,
                 evaluate_output, fit_output);
             REQUIRE(fit_status == 0);
@@ -1405,7 +1405,7 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
             }
 
             // Evaluate using C API that has dimension mismatch
-            int status_dimension_mismatch = spir_sampling_evaluate_dc(
+            int status_dimension_mismatch = spir_sampling_evaluate_dz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,
@@ -1416,7 +1416,7 @@ TEST_CASE("MatsubaraSampling", "[cinterface]") {
             );
             REQUIRE(status_dimension_mismatch == -2);
 
-            int fit_status_dimension_mismatch = spir_sampling_fit_cc(
+            int fit_status_dimension_mismatch = spir_sampling_fit_zz(
                 sampling,
                 SPIR_ORDER_COLUMN_MAJOR,
                 ndim,


### PR DESCRIPTION
This PR changes names of `evaluate_inplace_<blah>` and `fit_inplace_<blah>` (replacing `c` with `z`)