### PR TITLE
Introduce workflow creating release tags

### DIFF
--- a/.github/workflows/CreateTag.yml
+++ b/.github/workflows/CreateTag.yml
@@ -1,0 +1,41 @@
+name: Create Tag and Release from Version Header
+on:
+  push:
+    branches: [main, terasaki/introduce-release-note]
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Extract version from header
+      id: version
+      run: |
+        MAJOR=$(grep "#define SPARSEIR_VERSION_MAJOR" include/sparseir/version.h | awk '{print $3}')
+        MINOR=$(grep "#define SPARSEIR_VERSION_MINOR" include/sparseir/version.h | awk '{print $3}')
+        PATCH=$(grep "#define SPARSEIR_VERSION_PATCH" include/sparseir/version.h | awk '{print $3}')
+        VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION"
+
+        # Check if remote tag exists
+        git fetch --tags
+        if git tag -l | grep -q "^$VERSION$"; then
+          echo "Tag $VERSION already exists"
+          echo "should_create=false" >> $GITHUB_OUTPUT
+        else
+          echo "should_create=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create Release
+      if: steps.version.outputs.should_create == 'true'
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.version.outputs.version }}
+        name: Release ${{ steps.version.outputs.version }}
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CreateTag.yml
+++ b/.github/workflows/CreateTag.yml
@@ -1,7 +1,7 @@
 name: Create Tag and Release from Version Header
 on:
   push:
-    branches: [main, terasaki/introduce-release-note]
+    branches: [main]
 
 jobs:
   tag-and-release:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # libsparseir
 
 [![CMake on a single platform](https://github.com/SpM-lab/libsparseir/actions/workflows/CI_cmake.yml/badge.svg)](https://github.com/SpM-lab/libsparseir/actions/workflows/CI_cmake.yml)
+[![Create Tag and Release](https://github.com/SpM-lab/libsparseir/actions/workflows/CreateTag.yml/badge.svg)](https://github.com/SpM-lab/libsparseir/actions/workflows/CreateTag.yml)
 
 > [!WARNING]
 > This C++ project is still under construction. Please use other repositories:
@@ -17,6 +18,30 @@ This C++ library provides routines for constructing and working with the interme
 - routines for sparse sampling
 
 We use [tuwien-cms/libxprec](https://github.com/tuwien-cms/libxprec) as a double-double precision arithmetic library.
+
+## CI/CD
+
+This project uses GitHub Actions for continuous integration and automated releases:
+
+- **CI_cmake.yml**: Runs automated tests on every push and pull request to ensure code quality
+- **CreateTag.yml**: Automatically creates tags and releases when version numbers are updated in `include/sparseir/version.h`
+
+### Automated Release Process
+
+The release process is fully automated:
+
+1. Update version numbers in `include/sparseir/version.h` by modifying:
+   - `SPARSEIR_VERSION_MAJOR`
+   - `SPARSEIR_VERSION_MINOR`
+   - `SPARSEIR_VERSION_PATCH`
+
+2. Push changes to the main branch
+
+3. The GitHub Action will automatically:
+   - Extract the version from the header file
+   - Check if a tag with that version already exists
+   - Create a new tag and release if the version is new
+   - Generate release notes automatically
 
 ## Building and Installation
 


### PR DESCRIPTION
# Introduce Automated Release Workflow

This PR introduces an automated release workflow that streamlines the release process for libsparseir by automatically creating tags and GitHub releases based on version information in the header file (`include/sparseir/version.h`).