### PR TITLE
Introduce DeepWiki Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # libsparseir
-
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/SpM-lab/libsparseir)
 [![CMake on a single platform](https://github.com/SpM-lab/libsparseir/actions/workflows/CI_cmake.yml/badge.svg)](https://github.com/SpM-lab/libsparseir/actions/workflows/CI_cmake.yml)
 
 > [!WARNING]


### PR DESCRIPTION
📚 Add DeepWiki Badge for Enhanced Repository Documentation

This PR adds a DeepWiki badge to the README.md, providing users with instant access to AI-powered documentation for the libsparseir repository.