### PR TITLE
Fix shellcheck issues in GitHub Actions workflow

### DIFF
--- a/.github/workflows/CreateTag.yml
+++ b/.github/workflows/CreateTag.yml
@@ -16,16 +16,16 @@ jobs:
         MINOR=$(grep "#define SPARSEIR_VERSION_MINOR" include/sparseir/version.h | awk '{print $3}')
         PATCH=$(grep "#define SPARSEIR_VERSION_PATCH" include/sparseir/version.h | awk '{print $3}')
         VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "Version: $VERSION"
 
         # Check if remote tag exists
         git fetch --tags
         if git tag -l | grep -q "^$VERSION$"; then
           echo "Tag $VERSION already exists"
-          echo "should_create=false" >> $GITHUB_OUTPUT
+          echo "should_create=false" >> "$GITHUB_OUTPUT"
         else
-          echo "should_create=true" >> $GITHUB_OUTPUT
+          echo "should_create=true" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Create Release


### PR DESCRIPTION
## Summary
- Fixed shellcheck issues flagged by actionlint in `.github/workflows/CreateTag.yml`
- Added double quotes around `$GITHUB_OUTPUT` variable references to prevent globbing and word splitting

## Test plan
- [x] Verified actionlint passes without warnings
- [x] GitHub Actions workflow syntax remains valid

🤖 Generated with [Claude Code](https://claude.ai/code)