### PR TITLE
Fix repository-url

### DIFF
--- a/.github/workflows/PublishPyPI.yml
+++ b/.github/workflows/PublishPyPI.yml
@@ -121,7 +121,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-          repository-url: https://pypi.org/legacy/
+          repository-url: https://upload.pypi.org/legacy/
           verbose: true
           skip-existing: true
           attestations: false  # Disable attestations due to Sigstore service issues


### PR DESCRIPTION
Ref: https://github.com/pypa/gh-action-pypi-publish/blob/ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e/action.yml#L23